### PR TITLE
corpus_batch_size_unlimitation

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -397,7 +397,7 @@ class SentenceTransformer(nn.Sequential):
                     if max_ < feature_lists[feature_name][i].size(-1):
                         max_ = feature_lists[feature_name][i].size(-1)
                 
-                new_data = torch.ones(16, max_, dtype=torch.int64)
+                new_data = torch.ones(len(feature_lists[feature_name]), max_, dtype=torch.int64)
                
                 for i in range(len(feature_lists[feature_name])):
                     epo = max_ - feature_lists[feature_name][i].size(-1)
@@ -443,7 +443,7 @@ class SentenceTransformer(nn.Sequential):
             for i in range(len(feature_lists[feature_name])):
                 if max_ < feature_lists[feature_name][i].size(-1):
                     max_ = feature_lists[feature_name][i].size(-1)
-            new_data = torch.ones(16, max_, dtype=torch.int64)
+            new_data = torch.ones(len(feature_lists[feature_name]), max_, dtype=torch.int64)
             for i in range(len(feature_lists[feature_name])):
                 epo = max_ - feature_lists[feature_name][i].size(-1)
                 copy_feature = copy.deepcopy(feature_lists[feature_name][i].squeeze(0))


### PR DESCRIPTION
`def smart_batching_collate(self, batch):`에서
corpus batch size 16으로 limit 되어 있어서 batch size를 16보다 크게 할 경우 에러가 발생,
따라서 batch size를 `len(feature_lists[feature_name])`만큼으로 설정해주었습니다.

`smart_batch_collate` function의 다른 의도가 있는 것 같으나, 모르겠어서 임시방편으로 이렇게 해보았습니다. 혹시 16으로 제한하신 이유가 있으시면 가르쳐주시면 감사하겠습니다. 
